### PR TITLE
Update github linguist's calculation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored


### PR DESCRIPTION
The source of the package is written in python as opposed to jupyter notebook files. This gives a false impression of the language of the project. 

This is just me being pedantic here but I think it would be a nice addition for linguist to just reflect python as being the source language of the project.

This PR addresses this issue. :-)